### PR TITLE
fixed $projectname$ for android app

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp.Droid/Main.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Droid/Main.cs
@@ -15,7 +15,7 @@ using Windows.UI.Xaml.Media;
 namespace Microsoft.Toolkit.Uwp.SampleApp.Droid
 {
     [global::Android.App.ApplicationAttribute(
-        Label = "@string/ApplicationName",
+        Label = "@string/app_name",
         LargeHeap = true,
         HardwareAccelerated = true
         ,


### PR DESCRIPTION
Issue: #42

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
SampleApp is installed as `$projectname$` on android.

## What is the new behavior?
The defined "Microsoft.Toolkit.Uwp.SampleApp.Droid" app name should be shown now.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes