### PR TITLE
fixed invalid urls found in nuget packages metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,10 @@
     <Authors>nventive</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <PackageIconUrl>https://raw.githubusercontent.com/nventive/Uno.WindowsCommunityToolkit/uno/build/nuget.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/nventive/Uno.WindowsCommunityToolkit</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/nventive/Uno.WindowsCommunityToolkit/blob/uno/license.md</PackageLicenseUrl>
-    <PackageReleaseNotes>v5.1.0 release https://github.com/nventive/Uno.WindowsCommunityToolkit/releases</PackageReleaseNotes>
+    <PackageIconUrl>https://raw.githubusercontent.com/unoplatform/Uno.WindowsCommunityToolkit/uno/build/nuget.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/unoplatform/Uno.WindowsCommunityToolkit</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/unoplatform/Uno.WindowsCommunityToolkit/blob/uno/license.md</PackageLicenseUrl>
+    <PackageReleaseNotes>v5.1.0 release https://github.com/unoplatform/Uno.WindowsCommunityToolkit/releases</PackageReleaseNotes>
     <Copyright>(c) .NET Foundation and Contributors.  All rights reserved.</Copyright>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Toolkit.ruleset</CodeAnalysisRuleSet>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,10 @@
     <Authors>nventive</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <PackageIconUrl>https://raw.githubusercontent.com/https://github.com/nventive/Uno.WindowsCommunityToolkit/master/build/nuget.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/https://github.com/nventive/Uno.WindowsCommunityToolkit</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/https://github.com/nventive/Uno.WindowsCommunityToolkit/blob/master/license.md</PackageLicenseUrl>
-    <PackageReleaseNotes>v5.1.0 release https://github.com/https://github.com/nventive/Uno.WindowsCommunityToolkit/releases</PackageReleaseNotes>
+    <PackageIconUrl>https://raw.githubusercontent.com/nventive/Uno.WindowsCommunityToolkit/uno/build/nuget.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/nventive/Uno.WindowsCommunityToolkit</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/nventive/Uno.WindowsCommunityToolkit/blob/uno/license.md</PackageLicenseUrl>
+    <PackageReleaseNotes>v5.1.0 release https://github.com/nventive/Uno.WindowsCommunityToolkit/releases</PackageReleaseNotes>
     <Copyright>(c) .NET Foundation and Contributors.  All rights reserved.</Copyright>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Toolkit.ruleset</CodeAnalysisRuleSet>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
Issue: #40

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
Invalid urls showing up in nuget packages metadata.

## What is the new behavior?
They have been fixed now.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes