### PR TITLE
added workaround for duplicated 'targetsize' assets

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Microsoft.Toolkit.Uwp.SampleApp.Shared.projitems
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Microsoft.Toolkit.Uwp.SampleApp.Shared.projitems
@@ -464,6 +464,10 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.scale-150.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.scale-200.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.scale-400.png" />
+  </ItemGroup>
+
+  <!--  Workaround for https://github.com/unoplatform/uno/issues/1370  -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != 'MonoAndroid'">
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-16.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-16_altform-unplated.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-20.png" />
@@ -492,6 +496,8 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-80_altform-unplated.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-96.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-96_altform-unplated.png" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppBadgeLogo.scale-100.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppBadgeLogo.scale-125.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppBadgeLogo.scale-150.png" />


### PR DESCRIPTION
Issue: #45 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Android head won't build because of duplicated 'targetsize' assets.

## What is the new behavior?
Android head should build now.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
https://github.com/unoplatform/uno/issues/1370