### PR TITLE
added workaround for NRE from DeferLoadStrategy=Lazy

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Shell.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Shell.xaml
@@ -80,8 +80,8 @@
               </animations:Implicit.HideAnimations>
             </win:Border>
 
+            <!-- removed DeferLoadStrategy="Lazy" to work around: https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/50 -->
             <Grid x:Name="SamplePickerGrid"
-                  x:DeferLoadStrategy="Lazy"
                   Visibility="Collapsed"
                   VerticalAlignment="Top">
               <controls:DropShadowPanel VerticalContentAlignment="Stretch"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.xaml
@@ -21,8 +21,8 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
+                        <!-- removed DeferLoadStrategy="Lazy" to work around: https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/50 -->
                         <ContentPresenter x:Name="HeaderPresenter" 
-                                          x:DeferLoadStrategy="Lazy"
                                           Content="{TemplateBinding Header}" 
                                           ContentTemplate="{TemplateBinding HeaderTemplate}" 
                                           Grid.ColumnSpan="2"/>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.xaml
@@ -26,9 +26,9 @@
                 <ControlTemplate TargetType="controls:HeaderedTextBlock">
                     <StackPanel x:Name="Panel"
                                 Orientation="{TemplateBinding Orientation}">
+                        <!-- removed DeferLoadStrategy="Lazy" to work around: https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/50 -->
                         <ContentPresenter x:Name="HeaderContentPresenter"
                                           Grid.ColumnSpan="4"
-                                          x:DeferLoadStrategy="Lazy"
                                           AutomationProperties.AccessibilityView="Raw"
                                           AutomationProperties.Name="Header content"
                                           Content="{TemplateBinding Header}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Loading/Loading.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Loading/Loading.xaml
@@ -100,7 +100,8 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <ContentPresenter x:Name="ContentGrid" x:DeferLoadStrategy="Lazy" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                        <!-- removed DeferLoadStrategy="Lazy" to work around: https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/50 -->
+                        <ContentPresenter x:Name="ContentGrid" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                             <ContentPresenter.RenderTransform>
                                 <CompositeTransform></CompositeTransform>
                             </ContentPresenter.RenderTransform>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
@@ -30,9 +30,9 @@
                                     <RowDefinition Height="*" />
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
+                                <!-- removed DeferLoadStrategy="Lazy" to work around: https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/50 -->
                                 <ContentPresenter x:Name="HeaderContentPresenter"
                                                   Margin="12,0"
-                                                  x:DeferLoadStrategy="Lazy"
                                                   Content="{TemplateBinding MasterHeader}"
                                                   ContentTemplate="{TemplateBinding MasterHeaderTemplate}"
                                                   Visibility="Collapsed" />


### PR DESCRIPTION
Issue: #50

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Clicking on navigation bar item cause NullRerefenceException to be thrown.

## What is the new behavior?
Clicking on navigation bar item now opens the sample picker grid.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes