### PR TITLE
fixed demo area being covered by info area in narrow-state

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Microsoft.Toolkit.Uwp.SampleApp.Shared.projitems
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Microsoft.Toolkit.Uwp.SampleApp.Shared.projitems
@@ -385,6 +385,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Styles\ThemeInjector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TrackingManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Triggers\PaneStateTrigger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UnoPlatformShell.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -465,7 +466,6 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.scale-200.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.scale-400.png" />
   </ItemGroup>
-
   <!--  Workaround for https://github.com/unoplatform/uno/issues/1370  -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != 'MonoAndroid'">
     <Content Include="$(MSBuildThisFileDirectory)Assets\UWPCommunityToolkitSampleAppAppList.targetsize-16.png" />

--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml
@@ -1,4 +1,4 @@
-<Page
+﻿<Page
     x:Class="Microsoft.Toolkit.Uwp.SampleApp.SampleController"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -285,7 +285,7 @@
                     <VisualState.Setters>
                         <Setter Target="NarrowInfoButton.Visibility" Value="Visible" />
                         <Setter Target="SampleTitleBar.(Grid.ColumnSpan)" Value="2" />
-                        <Setter Target="InfoAreaPivot.Margin" Value="0,50,0,0" />
+						<Setter Target="InfoAreaGrid.Margin" Value="0,50,0,0" />
 
                         <Setter Target="InfoAreaGrid.(Grid.Column)" Value="0" />
                         <Setter Target="InfoAreaGrid.(Grid.ColumnSpan)" Value="2" />
@@ -311,7 +311,7 @@
                         <Setter Target="ExpandPane.Icon" Value="OpenPane" />
                         <Setter Target="SampleTitleBar.(Grid.ColumnSpan)" Value="1" />
                         <Setter Target="SampleTitleBar.(Grid.Column)" Value="0" />
-                        <Setter Target="InfoAreaPivot.Margin" Value="0,50,0,0" />
+						<Setter Target="InfoAreaGrid.Margin" Value="0,50,0,0" />
 
                         <Setter Target="InfoAreaGrid.(Grid.Column)" Value="0" />
                         <Setter Target="InfoAreaGrid.(Grid.ColumnSpan)" Value="2" />

--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="Microsoft.Toolkit.Uwp.SampleApp.SampleController"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -13,7 +13,8 @@
       xmlns:common="using:Microsoft.Toolkit.Uwp.SampleApp.Common"
       xmlns:core="using:Microsoft.Xaml.Interactions.Core"
       xmlns:models="using:Microsoft.Toolkit.Uwp.SampleApp.Models"
-	  mc:Ignorable="d xamarin">
+      xmlns:triggers="clr-namespace:Microsoft.Toolkit.Uwp.SampleApp.Shared.Triggers"
+      mc:Ignorable="d xamarin">
 
     <Grid>
 
@@ -93,7 +94,7 @@
                               Grid.Column="1"
                               Width="50"
                               Visibility="Collapsed"
-                              Click="{x:Bind OpenClosePane}">
+                              Click="NarrowInfoButton_OnClick">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE946;" />
                     </AppBarButton.Icon>
@@ -169,8 +170,8 @@
                                       Visibility="{x:Bind CanChangePaneState}"
                                       Icon="ClosePane"
                                       Width="50"
-									  Height="50"
-                                      Click="{x:Bind ExpandCollapsePane}" />
+                                      Height="50"
+                                      Click="ExpandPane_OnClick" />
                     </Pivot.LeftHeader>
 
                     <PivotItem x:Name="PropertiesPivotItem"
@@ -255,7 +256,7 @@
                                         StackMode="QueueBehind"
                                         Margin="10"
                                         Canvas.ZIndex="999" />
-            
+
             <Grid x:Name="waitRing"
                     Grid.Row="1"
                     Grid.RowSpan="3"
@@ -271,6 +272,7 @@
                                 IsActive="True" />
             </Grid>
         </Grid>
+
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="WindowStates"
                               CurrentStateChanged="WindowStates_CurrentStateChanged">
@@ -302,7 +304,7 @@
                               CurrentStateChanged="PaneStates_CurrentStateChanged">
                 <VisualState x:Name="Full">
                     <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind SidePaneState.Equals(models:PaneState.Full), Mode=OneWay}" />
+                        <triggers:PaneStateTrigger Binding="{x:Bind SidePaneState, Mode=OneWay}" Value="Full" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="InfoAreaGrid.Visibility" Value="Visible" />
@@ -320,7 +322,7 @@
                 </VisualState>
                 <VisualState x:Name="Show">
                     <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind SidePaneState.Equals(models:PaneState.Normal), Mode=OneWay}" />
+                        <triggers:PaneStateTrigger Binding="{x:Bind SidePaneState, Mode=OneWay}" Value="Normal" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="InfoAreaGrid.Visibility" Value="Visible" />
@@ -329,7 +331,7 @@
                 </VisualState>
                 <VisualState x:Name="Hide">
                     <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind SidePaneState.Equals(models:PaneState.Closed), Mode=OneWay}" />
+                        <triggers:PaneStateTrigger Binding="{x:Bind SidePaneState, Mode=OneWay}" Value="Closed" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="InfoAreaGrid.Visibility" Value="Collapsed" />
@@ -338,7 +340,7 @@
                 </VisualState>
                 <VisualState x:Name="None">
                     <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind SidePaneState.Equals(models:PaneState.None), Mode=OneWay}" />
+                        <triggers:PaneStateTrigger Binding="{x:Bind SidePaneState, Mode=OneWay}" Value="None" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="InfoAreaGrid.Visibility" Value="Collapsed" />

--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             return theme;
         }
 
+        private async void NarrowInfoButton_OnClick(object sender, RoutedEventArgs e) => OpenClosePane();
+
         public void OpenClosePane()
         {
             if (CanChangePaneState)
@@ -122,6 +124,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 }
             }
         }
+
+        private async void ExpandPane_OnClick(object sender, RoutedEventArgs e) => ExpandCollapsePane();
 
         public void ExpandCollapsePane()
         {
@@ -328,7 +332,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 }
                 else
                 {
-                    SidePaneState = _onlyDocumentation ? PaneState.Full : PaneState.Normal;
+                    SidePaneState = _onlyDocumentation
+                        ? PaneState.Full
+                        : ((FrameworkElement)Windows.UI.Xaml.Window.Current.Content).ActualWidth > 700
+                            ? PaneState.Normal
+                            : PaneState.Closed;
                 }
 
                 Shell.Current.SetAppTitle($"{CurrentSample.CategoryName} > {CurrentSample.Name}");

--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Triggers/PaneStateTrigger.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Triggers/PaneStateTrigger.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Toolkit.Uwp.SampleApp.Models;
+using Windows.UI.Xaml;
+
+namespace Microsoft.Toolkit.Uwp.SampleApp.Shared.Triggers
+{
+    public class PaneStateTrigger : StateTriggerBase
+	{
+        #region Property: Binding
+        public static readonly DependencyProperty BindingProperty = DependencyProperty.Register(
+            nameof(Binding),
+            typeof(PaneState),
+            typeof(PaneStateTrigger),
+            new PropertyMetadata(default(PaneState), (s, e) => (s as PaneStateTrigger)?.UpdateTrigger()));
+
+        public PaneState Binding
+        {
+            get => (PaneState)GetValue(BindingProperty);
+            set => SetValue(BindingProperty, value);
+        }
+        #endregion
+
+        #region Property: Value
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+            nameof(Value),
+            typeof(PaneState),
+            typeof(PaneStateTrigger),
+            new PropertyMetadata(default(PaneState), (s, e) => (s as PaneStateTrigger)?.UpdateTrigger()));
+
+        public PaneState Value
+        {
+            get => (PaneState)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+        #endregion
+
+        private void UpdateTrigger() => SetActive(Binding == Value);
+    }
+}


### PR DESCRIPTION
Issue: #n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`InfoAreaGrid` is block the `DemoAreaGrid`, and there is no way to hide/move it

## What is the new behavior?
`DemoAreaGrid` is no longer blocked by `InfoAreaGrid`

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
`x:Bind` with expression is not support in Uno. See: https://github.com/unoplatform/uno/issues/347