### PR TITLE
added cors bypass for RSS parser sample

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/SamplePages/RssParser/RssParserPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/SamplePages/RssParser/RssParserPage.xaml.cs
@@ -1,10 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 using System;
 using System.Collections.ObjectModel;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Toolkit.Parsers.Rss;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
@@ -18,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public RssParserPage()
         {
             this.InitializeComponent();
-			Loaded += (s, e) => ParseRSS();
+            Loaded += (s, e) => ParseRSS();
         }
 
         public string Url { get; set; } = "https://visualstudiomagazine.com/rss-feeds/news.aspx";
@@ -28,7 +29,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             string feed = null;
             RSSFeed.Clear();
 
+#if __WASM__
+            using (var client = new HttpClient(new CorsBypassHandler()))
+#else
             using (var client = new HttpClient())
+#endif
             {
                 try
                 {
@@ -66,5 +71,24 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
             RSSList.SelectedItem = null;
         }
+
+#if __WASM__
+        public class CorsBypassHandler : DelegatingHandler
+        {
+            public CorsBypassHandler()
+            {
+                InnerHandler = new HttpClientHandler();
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var builder = new UriBuilder(request.RequestUri);
+                builder.Host = "cors-anywhere.herokuapp.com";
+                builder.Path = request.RequestUri.Host + builder.Path;
+
+                return base.SendAsync(new HttpRequestMessage(request.Method, builder.Uri), cancellationToken);
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
Issue: #61

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Rss Parser sample can't load feed because of CORS:
> Access to fetch at 'https://visualstudiomagazine.com/rss-feeds/news.aspx' from origin 'http://localhost:49996' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

## What is the new behavior?
cors-anywhere is used to bypass this.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
https://github.com/Rob--W/cors-anywhere