### PR TITLE
fixed xamlns `clr-namespace: ...` not working on uwp

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/Pages/SampleController.xaml
@@ -13,7 +13,7 @@
       xmlns:common="using:Microsoft.Toolkit.Uwp.SampleApp.Common"
       xmlns:core="using:Microsoft.Xaml.Interactions.Core"
       xmlns:models="using:Microsoft.Toolkit.Uwp.SampleApp.Models"
-      xmlns:triggers="clr-namespace:Microsoft.Toolkit.Uwp.SampleApp.Shared.Triggers"
+      xmlns:triggers="using:Microsoft.Toolkit.Uwp.SampleApp.Shared.Triggers"
       mc:Ignorable="d xamarin">
 
     <Grid>


### PR DESCRIPTION
Issue: #64

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Uwp fails with:
```
C:\code\Uno.WindowsCommunityToolkit\Microsoft.Toolkit.Uwp.SampleApp.Shared\Pages\SampleController.xaml(343,26): 
XamlCompiler error WMC0001: Unknown type 'PaneStateTrigger' in XML namespace 
'clr-namespace:Microsoft.Toolkit.Uwp.SampleApp.Shared.Triggers;assembly=Microsoft.Toolkit.Uwp.SampleApp, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null'
```

## What is the new behavior?
Uwp build should pass.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes