### PR TITLE
Update to uno latest, remove splitter sample

### DIFF
--- a/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
+++ b/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
@@ -28,11 +28,11 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="2.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid80' or '$(TargetFramework)' == 'xamarinios10' or '$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 		<Reference Include="System.Runtime.Serialization" />
 		<Reference Include="System.Xml" />
 		<Reference Include="System.Xml.Linq" />

--- a/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
+++ b/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
@@ -28,11 +28,11 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="2.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid80' or '$(TargetFramework)' == 'xamarinios10' or '$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 		<Reference Include="System.Runtime.Serialization" />
 		<Reference Include="System.Xml" />
 		<Reference Include="System.Xml.Linq" />

--- a/Microsoft.Toolkit.Uwp.Connectivity/Microsoft.Toolkit.Uwp.Connectivity.csproj
+++ b/Microsoft.Toolkit.Uwp.Connectivity/Microsoft.Toolkit.Uwp.Connectivity.csproj
@@ -16,7 +16,7 @@
 
   </ItemGroup>
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.Connectivity/Microsoft.Toolkit.Uwp.Connectivity.csproj
+++ b/Microsoft.Toolkit.Uwp.Connectivity/Microsoft.Toolkit.Uwp.Connectivity.csproj
@@ -16,7 +16,7 @@
 
   </ItemGroup>
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.DeveloperTools/Microsoft.Toolkit.Uwp.DeveloperTools.csproj
+++ b/Microsoft.Toolkit.Uwp.DeveloperTools/Microsoft.Toolkit.Uwp.DeveloperTools.csproj
@@ -16,11 +16,11 @@
   </ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Microsoft.Toolkit.Uwp.DeveloperTools/Microsoft.Toolkit.Uwp.DeveloperTools.csproj
+++ b/Microsoft.Toolkit.Uwp.DeveloperTools/Microsoft.Toolkit.Uwp.DeveloperTools.csproj
@@ -16,11 +16,11 @@
   </ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Microsoft.Toolkit.Uwp.SampleApp.Droid/Microsoft.Toolkit.Uwp.SampleApp.Droid.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Droid/Microsoft.Toolkit.Uwp.SampleApp.Droid.csproj
@@ -90,7 +90,7 @@
     <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1-uno.28</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj">

--- a/Microsoft.Toolkit.Uwp.SampleApp.Droid/Microsoft.Toolkit.Uwp.SampleApp.Droid.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Droid/Microsoft.Toolkit.Uwp.SampleApp.Droid.csproj
@@ -90,7 +90,7 @@
     <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1-uno.28</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj">

--- a/Microsoft.Toolkit.Uwp.SampleApp.Shared/SamplePages/samples.json
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Shared/SamplePages/samples.json
@@ -168,16 +168,16 @@
       //  "Icon": "/SamplePages/ScrollHeader/ScrollHeader.png",
       //  "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/controls/ScrollHeader.md"
       //},
-      {
-        "Name": "GridSplitter",
-        "Type": "GridSplitterPage",
-        "Subcategory": "Layout",
-        "About": "GridSplitter represents the control that redistributes space between columns or rows of a Grid control.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter",
-        "XamlCodeFile": "GridSplitter.bind",
-        "Icon": "/SamplePages/GridSplitter/GridSplitter.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/controls/GridSplitter.md"
-      },
+      //{
+      //  "Name": "GridSplitter",
+      //  "Type": "GridSplitterPage",
+      //  "Subcategory": "Layout",
+      //  "About": "GridSplitter represents the control that redistributes space between columns or rows of a Grid control.",
+      //  "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter",
+      //  "XamlCodeFile": "GridSplitter.bind",
+      //  "Icon": "/SamplePages/GridSplitter/GridSplitter.png",
+      //  "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/controls/GridSplitter.md"
+      //},
       //{
       //  "Name": "DropShadowPanel",
       //  "Type": "DropShadowPanelPage",

--- a/Microsoft.Toolkit.Uwp.SampleApp.Wasm/Microsoft.Toolkit.Uwp.SampleApp.Wasm.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Wasm/Microsoft.Toolkit.Uwp.SampleApp.Wasm.csproj
@@ -32,15 +32,15 @@
   </ItemGroup>
       
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
     <PackageReference Include="Uno.UI.Sample.Banner" Version="1.44.0-dev.23" />
     <Reference Include="System.Net.Http" />
-    <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0" />
+    <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Toolkit.Uwp.SampleApp.Wasm/Microsoft.Toolkit.Uwp.SampleApp.Wasm.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp.Wasm/Microsoft.Toolkit.Uwp.SampleApp.Wasm.csproj
@@ -32,15 +32,15 @@
   </ItemGroup>
       
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.5" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
     <PackageReference Include="Uno.UI.Sample.Banner" Version="1.44.0-dev.23" />
     <Reference Include="System.Net.Http" />
-    <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.5" />
+    <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Toolkit.Uwp.SampleApp.iOS/Microsoft.Toolkit.Uwp.SampleApp.iOS.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp.iOS/Microsoft.Toolkit.Uwp.SampleApp.iOS.csproj
@@ -118,7 +118,7 @@
     <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1-uno.28</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj">

--- a/Microsoft.Toolkit.Uwp.SampleApp.iOS/Microsoft.Toolkit.Uwp.SampleApp.iOS.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp.iOS/Microsoft.Toolkit.Uwp.SampleApp.iOS.csproj
@@ -118,7 +118,7 @@
     <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1-uno.28</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj">

--- a/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
@@ -119,7 +119,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.Core" Version="1.29.0-dev.109" />
+    <PackageReference Include="Uno.Core" Version="1.29.0" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
     </PackageReference>

--- a/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
@@ -119,7 +119,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.Core" Version="1.29.0-dev.103" />
+    <PackageReference Include="Uno.Core" Version="1.29.0-dev.109" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
     </PackageReference>

--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <!-- This is here to prevent a conflict in certain circumstances -->
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
     
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj" />  
     <ProjectReference Include="..\Microsoft.Toolkit.Services\Microsoft.Toolkit.Services.csproj" />
@@ -25,7 +25,7 @@
     
   </ItemGroup>
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <!-- This is here to prevent a conflict in certain circumstances -->
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
     
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj" />  
     <ProjectReference Include="..\Microsoft.Toolkit.Services\Microsoft.Toolkit.Services.csproj" />
@@ -25,7 +25,7 @@
     
   </ItemGroup>
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
@@ -13,7 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 		<PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1-uno.28" />
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 		<ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI\Microsoft.Toolkit.Uwp.UI.csproj" />
 	</ItemGroup>
 	
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
@@ -13,7 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 		<PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1-uno.28" />
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 		<ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI\Microsoft.Toolkit.Uwp.UI.csproj" />
 	</ItemGroup>
 	
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.csproj
@@ -29,11 +29,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'monoandroid80' or '$(TargetFramework)' == 'xamarinios10' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.csproj
@@ -29,11 +29,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'monoandroid80' or '$(TargetFramework)' == 'xamarinios10' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Graph/Microsoft.Toolkit.Uwp.UI.Controls.Graph.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Graph/Microsoft.Toolkit.Uwp.UI.Controls.Graph.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'  or '$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.7" />
 	</ItemGroup>
 
@@ -43,7 +43,7 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
   </ItemGroup>
  
   <ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Graph/Microsoft.Toolkit.Uwp.UI.Controls.Graph.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Graph/Microsoft.Toolkit.Uwp.UI.Controls.Graph.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'  or '$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.7" />
 	</ItemGroup>
 
@@ -43,7 +43,7 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+    <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
   </ItemGroup>
  
   <ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Uno.ColorCode.UWP" Version="2.0.5-gd0f1a63314" />
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 		<ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.csproj" />
 		<ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj" />
 	</ItemGroup>
@@ -24,7 +24,7 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Uno.ColorCode.UWP" Version="2.0.5-gd0f1a63314" />
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 		<ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.csproj" />
 		<ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj" />
 	</ItemGroup>
@@ -24,7 +24,7 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI/Microsoft.Toolkit.Uwp.UI.csproj
+++ b/Microsoft.Toolkit.Uwp.UI/Microsoft.Toolkit.Uwp.UI.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp.UI/Microsoft.Toolkit.Uwp.UI.csproj
+++ b/Microsoft.Toolkit.Uwp.UI/Microsoft.Toolkit.Uwp.UI.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+	  <PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
+++ b/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
@@ -13,13 +13,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 
 		<ProjectReference Include="..\Microsoft.Toolkit\Microsoft.Toolkit.csproj" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />

--- a/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
+++ b/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
@@ -13,13 +13,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 
 		<ProjectReference Include="..\Microsoft.Toolkit\Microsoft.Toolkit.csproj" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4019" />
+		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4155" />
 	</ItemGroup>
 
 	<Import Project="..\uno.ui.include.props" />


### PR DESCRIPTION
Splitter sample is disabled for an AOT issue that may be fixed with latest mono.
