### PR TITLE
fix(masterDetailsView): Fix selected item is not displayed in the det…

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
+using Uno.Extensions.Specialized;
 using Windows.ApplicationModel;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
 
@@ -107,8 +110,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             var view = (MasterDetailsView)d;
 
-            var newValue = (int)e.NewValue < 0 ? null : view.Items[(int)e.NewValue];
-            var oldValue = e.OldValue == null ? null : view.Items.ElementAtOrDefault((int)e.OldValue);
+            var newValue = e.NewValue is int newIndex && newIndex >= 0 ? view.GetItems()?.ElementAt(newIndex) : default;
+            var oldValue = e.OldValue is int oldIndex ? view.GetItems()?.ElementAtOrDefault(oldIndex) : default;
 
             // check if selection actually changed
             if (view.SelectedItem != newValue)
@@ -130,7 +133,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var view = (MasterDetailsView)d;
-            var index = e.NewValue == null ? -1 : view.Items.IndexOf(e.NewValue);
+
+            var index = e.NewValue == null ? -1 : view.GetItems()?.IndexOf(e.NewValue) ?? -1;
 
             // check if selection actually changed
             if (view.SelectedIndex != index)
@@ -580,5 +584,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 masterList.Focus(FocusState.Programmatic);
             }
         }
+
+#if HAS_UNO
+        // Work around that the ItemsControl.Items property on uno is not filled when using the ItemsSource
+        // https://github.com/unoplatform/uno/issues/2347
+        private IEnumerable GetItems()
+        {
+            var itemsSource = ItemsSource is CollectionViewSource cvs
+                ? (object)cvs.View
+                : ItemsSource;
+
+            return itemsSource as IEnumerable ?? Items;
+        }
+#else
+        private IEnumerable GetItems() => Items;
+#endif
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
-using Uno.Extensions.Specialized;
 using Windows.ApplicationModel;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -14,6 +13,9 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
+#if HAS_UNO
+using Uno.Extensions.Specialized;
+#endif
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -597,7 +599,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             return itemsSource as IEnumerable ?? Items;
         }
 #else
-        private IEnumerable GetItems() => Items;
+        private ItemCollection GetItems() => Items;
 #endif
     }
 }


### PR DESCRIPTION
## Fixes https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/96

## BugFix
Fix the selection not working in the `MasterDetailsView`

## What is the current behavior?
As the `ItemsControl.Items` not fulfilled properly when using an `ItemsSource` (https://github.com/unoplatform/uno/issues/2347) the `Selected<Index|Item>Changed` callbacks was not able to validate the new selection and was then ignoring it.

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes
