### PR TITLE
added uno-specific platforms to Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,25 +37,13 @@ NuGet Package(s):
 
 Package Version(s): 
 
-Windows 10 Build Number:
-- [ ] Fall Creators Update (16299)
-- [ ] April 2018 Update (17134)
-- [ ] October 2018 Update (17763)
-- [ ] May 2019 Update (18362)
-- [ ] Insider Build (build number: )
-
-App min and target version:
-- [ ] Fall Creators Update (16299)
-- [ ] April 2018 Update (17134)
-- [ ] October 2018 Update (17763)
-- [ ] May 2019 Update (18362)
-- [ ] Insider Build (xxxxx)
-
 Device form factor:
-- [ ] Desktop
-- [ ] Xbox
-- [ ] Surface Hub
-- [ ] IoT
+- [ ] Windows
+- [ ] macOS
+- [ ] iOS
+- [ ] Android
+- [ ] WebAssembly
+- [ ] WebAssembly renderers for Xamarin.Forms
 
 Visual Studio 
 - [ ] 2017 (version: )


### PR DESCRIPTION
## Fixes #n/a

## PR Type
What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?
Current "But Report" issue template have parts that are asking uwp specific context and not uno specific one.

## What is the new behavior?
Removed UWP relevant context questions, and added Uno relevant ones.