### PR TITLE
DataGrid Fix for Items not being measured

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -3349,6 +3349,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
 #if !HAS_UNO
                 ComputeScrollBarsLayout();
+#else
+                UpdateDisplayedRows(this.DisplayData.FirstScrollingSlot, this.CellsHeight);
 #endif
             }
 


### PR DESCRIPTION
## Fixes https://github.com/unoplatform/uno/issues/4658

Using the `DataGrid.ItemsSource` property may not work when assigned synchronously during the parent's loading. The items are not shown. This was caused by a missing call to `UpdateDisplayedRows()` which is responsible for adding the item scrolling slots and taking their cell height into account later on during the Measure phase.  

## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
 The items are not shown.

## What is the new behavior?
 The items are shown.