### PR TITLE
Remove Border from DataGridTextColumn content

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridTextColumn.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridTextColumn.cs
@@ -244,8 +244,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 textBlockElement.SetBinding(TextBlock.TextProperty, this.Binding);
             }
 
-            // UNO TODO
-            return new Border { Child = textBlockElement };
+            return textBlockElement;
         }
 
         /// <summary>
@@ -292,8 +291,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             TextBox textBox = element as TextBox;
             if (textBox == null)
             {
-                // UNO TODO
-                TextBlock textBlock = (element as Border)?.Child as TextBlock;
+                TextBlock textBlock = element as TextBlock;
                 if (textBlock == null)
                 {
                     throw DataGridError.DataGrid.ValueIsNotAnInstanceOfEitherOr("element", typeof(TextBox), typeof(TextBlock));
@@ -381,8 +379,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
             else
             {
-                // UNO TODO
-                TextBlock textBlock = (element as Border)?.Child as TextBlock;
+                TextBlock textBlock = element as TextBlock;
                 if (textBlock != null)
                 {
                     RefreshForeground(textBlock, computedRowForeground);


### PR DESCRIPTION
## Fixes https://github.com/unoplatform/uno/issues/4698

`DataGridTextColumn`'s `GenerateElement()` will no longer return a `TextBlock` wrapped in a `Border`

## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
`DataGridTextColumn`'s `GenerateElement()` returns a `TextBlock` wrapped in a `Border`


## What is the new behavior?
`DataGridTextColumn`'s `GenerateElement()` will no longer return a `TextBlock` wrapped in a `Border`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes