### PR TITLE
Add ContentTemplate Binding to DataGridColumnHeader

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.xaml
@@ -576,7 +576,7 @@
                                 <ColumnDefinition MinWidth="32" Width="Auto"/>
                             </Grid.ColumnDefinitions>
 
-                            <ContentPresenter Content="{TemplateBinding Content}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                            <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
 
                             <FontIcon Grid.Column="1" x:Name="SortIcon" FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{ThemeResource SortIconAscending}" FontSize="12"
                                 Foreground="{ThemeResource DataGridColumnHeaderForegroundBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0"/>


### PR DESCRIPTION
## Closes https://github.com/unoplatform/uno/issues/4699

Fixes issue with ContentTemplate not being set on the DataGrid's ColumnHeader Style
This is a required workaround due to: https://github.com/unoplatform/uno/issues/857

## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
Setting a ContentTemplate in a Style with TargetType `DataGridColumnHeader` does not display them template

## What is the new behavior?
`DataGridColumnHeader`'s ContentPresenter now has a `TemplateBinding` to the Parent `ContentTemplate`
