### PR TITLE
fix: Ensure focus is properly preserved on edited cell

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -6739,7 +6739,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // Uno specific: Moving the edited element to the cell causes it to lose the native focus
             // while the managed focus remains. In UWP this does not happen, as the Loaded event for the
             // element is called *after* this method ends. Uno's control lifecycle is different, so
-            // we need to use this approach instead.
+            // we need to use this approach instead. Uno issue: https://github.com/unoplatform/uno/issues/2895
             if (isCellEdited && EditingRow != null)
             {
                 FocusEditingCell(this.ContainsFocus || _focusEditingControl /*setFocus*/);

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -6734,6 +6734,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             dataGridCell.Content = element;
+
+#if HAS_UNO
+            // Uno specific: Moving the edited element to the cell causes it to lose the native focus
+            // while the managed focus remains. In UWP this does not happen, as the Loaded event for the
+            // element is called *after* this method ends. Uno's control lifecycle is different, so
+            // we need to use this approach instead.
+            if (isCellEdited && EditingRow != null)
+            {
+                FocusEditingCell(this.ContainsFocus || _focusEditingControl /*setFocus*/);
+            }
+#endif
         }
 
         private void PreparingCellForEditPrivate(FrameworkElement editingElement)
@@ -6753,7 +6764,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             DiagnosticsDebug.Assert(_editingColumnIndex < this.ColumnsItemsInternal.Count, "Expected _editingColumnIndex smaller than this.ColumnsItemsInternal.Count.");
             DiagnosticsDebug.Assert(_editingColumnIndex == this.CurrentColumnIndex, "Expected _editingColumnIndex equals CurrentColumnIndex.");
 
+#if !HAS_UNO
             FocusEditingCell(this.ContainsFocus || _focusEditingControl /*setFocus*/);
+#endif
 
             // Prepare the cell for editing and raise the PreparingCellForEdit event for all columns
             DataGridColumn dataGridColumn = this.CurrentColumn;


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other --> 

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #

Native focus is lost due to the fact that `Loaded` event is called too early and the the content is moved.

<!-- Add the relevant issue number after the "#" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
