### PR TITLE
Remove `RichEditBox` resource dictionary reference

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/Themes/Generic.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/Themes/Generic.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.xaml" />
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls.Input/RemoteDevicePicker/RemoteDevicePicker.xaml" />
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml" />
-        <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls.Input/RichSuggestBox/RichSuggestBox.xaml" />
+        <!-- Uno specific: RichSuggestBox is not present in Uno -->
+        <!--<ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls.Input/RichSuggestBox/RichSuggestBox.xaml" />-->
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>


### PR DESCRIPTION
The `Generic.xaml` file in `Input` library was referencing `RichEditBox` which is completely removed from Uno version of toolkit (due to missing APIs). This removes the resource dictionary reference to avoid crashes at runtime.