### PR TITLE
fix: Disable datagrid invalidate during measure to avoid layout freeze

### DIFF
--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridFeatureConfiguation.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridFeatureConfiguation.cs
@@ -16,6 +16,13 @@ namespace CommunityToolkit.WinUI.UI.Controls
         /// This configuration is required until https://github.com/unoplatform/uno/issues/3519 is fixed. Without this
         /// the layout engine turns into a loop and consumes CPU excessively, or freezes the app.
         /// </remarks>
-        public static bool EnableInvalidateMeasureInMeasureOverride { get; set; } = true;
+        public static bool EnableInvalidateMeasureInMeasureOverride { get; set; }
+
+#if __IOS__
+            // Workaround for invalidation issue (https://github.com/unoplatform/uno/issues/3519)
+            = false;
+#else
+            = true;
+#endif
     }
 }


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno/issues/3519