### PR TITLE
chore: Restore mouse attached properties

### DIFF
--- a/CommunityToolkit.WinUI.UI/Extensions/FrameworkElement/FrameworkElementExtensions.Mouse.cs
+++ b/CommunityToolkit.WinUI.UI/Extensions/FrameworkElement/FrameworkElementExtensions.Mouse.cs
@@ -8,8 +8,6 @@ using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 
-#if !HAS_UNO
-
 namespace CommunityToolkit.WinUI.UI
 {
     /// <inheritdoc cref="FrameworkElementExtensions"/>
@@ -121,5 +119,3 @@ namespace CommunityToolkit.WinUI.UI
         }
     }
 }
-
-#endif


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/203