### PR TITLE
fix: Adjust logical name to avoid ios tooling exception

### DIFF
--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/CommunityToolkit.WinUI.UI.Controls.DataGrid.csproj
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/CommunityToolkit.WinUI.UI.Controls.DataGrid.csproj
@@ -20,6 +20,7 @@
       <CustomToolNamespace>$(RootNamespace)</CustomToolNamespace>
       <!-- The 'ManifestResourceName' metadata changes the default manifest naming scheme -->
       <ManifestResourceName>$(RootNamespace).%(Filename)</ManifestResourceName>
+      <LogicalName>$(RootNamespace).%(Filename)</LogicalName>
     </EmbeddedResource>
     <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Adjust embedded resource name for https://github.com/xamarin/xamarin-macios/pull/21277