### PR TITLE
fix(DataGrid): not displaying cells from last columns when resized from scrolled state

### DIFF
--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridColumns.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridColumns.cs
@@ -1245,6 +1245,14 @@ namespace CommunityToolkit.WinUI.UI.Controls
                             _horizontalOffset -= GetEdgedColumnWidth(dataGridColumn);
                             dataGridColumn = this.ColumnsInternal.GetPreviousVisibleScrollingColumn(dataGridColumn);
                         }
+
+                        if (_horizontalOffset == 0 && cx < displayWidth)
+                        {
+                            // if the columns have been scrolled, and all visible columns are fully rendered in the available space,
+                            // then HorizontalAdjustment needs to be updated so that DataGridCellsPresenter.ShouldDisplayCell
+                            // don't hide columns based on the old value.
+                            HorizontalAdjustment = displayWidth - cx;
+                        }
                     }
 
                     // third try to partially scroll in first scrolled off column


### PR DESCRIPTION
for: CommunityToolkit/WindowsCommunityToolkit#5010

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
In certain situation, when the data-grid resizes from needing a scrollbar to not, certain cells is no longer visible.

## What is the new behavior?
Scrolled cells will remain visible after resize.

## PR Checklist
Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [x] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

## Other information
same fix on wct: CommunityToolkit/WindowsCommunityToolkit#5011