### PR TITLE
fix: work around DataGridDataConnection bug that attempts to read removed items from the data source

### DIFF
--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridDataConnection.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridDataConnection.cs
@@ -952,6 +952,7 @@ namespace CommunityToolkit.WinUI.UI.Controls.DataGridInternals
                 case CollectionChange.ItemRemoved:
                     if (!this.IsGrouping)
                     {
+                        // Uno comment: This is incorrect as sender[index] is already removed at this point, but we have no way to get the removed item from IObservableVector.
                         // If we're grouping then we handle this through the CollectionViewGroup notifications.
                         // Remove is a single item operation.
                         _owner.RemoveRowAt(index, sender[index]);

--- a/CommunityToolkit.WinUI.UI/AdvancedCollectionView/AdvancedCollectionView.Events.cs
+++ b/CommunityToolkit.WinUI.UI/AdvancedCollectionView/AdvancedCollectionView.Events.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.UI.Xaml.Data;
+using System.Collections.Specialized;
 using Windows.Foundation.Collections;
 
 namespace CommunityToolkit.WinUI.UI
@@ -55,6 +56,29 @@ namespace CommunityToolkit.WinUI.UI
             }
 
             VectorChanged?.Invoke(this, e);
+
+            if (CollectionChanged != null)
+            {
+                switch (e.CollectionChange)
+                {
+                    case CollectionChange.ItemInserted:
+                        CollectionChanged.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, _view[(int)e.Index], (int)e.Index));
+                        break;
+                    case CollectionChange.ItemRemoved:
+                        if (e is VectorChangedEventArgs args)
+                        {
+                            CollectionChanged.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, args.Item, (int)e.Index));
+                        }
+
+                        break;
+                    case CollectionChange.ItemChanged:
+                        CollectionChanged.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, _view[(int)e.Index], _view[(int)e.Index], (int)e.Index));
+                        break;
+                    case CollectionChange.Reset:
+                        CollectionChanged.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                        break;
+                }
+            }
 
             // ReSharper disable once ExplicitCallerInfoArgument
             OnPropertyChanged(nameof(Count));

--- a/CommunityToolkit.WinUI.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/CommunityToolkit.WinUI.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -22,7 +22,7 @@ namespace CommunityToolkit.WinUI.UI
     /// <summary>
     /// A collection view implementation that supports filtering, sorting and incremental loading
     /// </summary>
-    public partial class AdvancedCollectionView : IAdvancedCollectionView, /*UNO TODO*/System.ComponentModel.INotifyPropertyChanged, ISupportIncrementalLoading, IComparer<object>
+    public partial class AdvancedCollectionView : IAdvancedCollectionView, /*UNO TODO*/System.ComponentModel.INotifyPropertyChanged, ISupportIncrementalLoading, IComparer<object>, INotifyCollectionChanged
     {
         private readonly List<object> _view;
 
@@ -416,6 +416,11 @@ namespace CommunityToolkit.WinUI.UI
 
             return 0;
         }
+
+        /// <summary>
+        /// Occurs when the collection changes.
+        /// </summary>
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
 
         /// <summary>
         /// Occurs when a property value changes.

--- a/CommunityToolkit.WinUI.UI/AdvancedCollectionView/VectorChangedEventArgs.cs
+++ b/CommunityToolkit.WinUI.UI/AdvancedCollectionView/VectorChangedEventArgs.cs
@@ -21,6 +21,7 @@ namespace CommunityToolkit.WinUI.UI
         {
             CollectionChange = cc;
             Index = (uint)index;
+            Item = item;
         }
 
         /// <summary>
@@ -38,5 +39,7 @@ namespace CommunityToolkit.WinUI.UI
         /// The zero-based position where the change occurred in the vector, if applicable.
         /// </returns>
         public uint Index { get; }
+
+        public object Item { get; }
     }
 }


### PR DESCRIPTION
closes https://github.com/unoplatform/kahua-private/issues/392

This fixes the problem only for AdvancedCollectionView. Other IObservableVector implementations that don't implement INotifyCollectionChanged will face the same problem.