### PR TITLE
chore: align WCT dev versioning for maintenance releases

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,6 +1,7 @@
 trigger:
 - master
 - rel/*
+- unorel/winui/*
 
 jobs:
 - job: Windows
@@ -20,7 +21,7 @@ jobs:
     value: C:\Microsoft\AndroidNDK64\android-ndk-r16b
 
   steps:
-  
+
   - task: UseDotNet@2
     inputs:
       packageType: 'runtime'

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.200-dev.{height}",
+  "version": "7.1.205-dev.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
## Summary
This updates the WCT maintenance flow by adding CI trigger coverage for unorel/winui/* and advancing the uno branch prerelease line to 7.1.205-dev.{height}.

## Why
unorel/winui/* backport merges should produce CI artifacts automatically, and the previous 7.1.200-dev.* prerelease line looked stale/confusing after stable 7.1.204 releases.

<br>

_Related to https://github.com/unoplatform/kahua-private/issues/392_