### PR TITLE
fix: bump stable version to 7.1.205

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,12 +55,6 @@ jobs:
       version: '5.0.402'
     displayName: Use .NET SDK 5.0.402
 
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '8.0.x'
-    displayName: Use .NET SDK 8.x
-
   - template: build/ci/dotnet-install-windows.yml
   - template: build/ci/jdk-setup.yml
 
@@ -68,17 +62,11 @@ jobs:
     inputs:
       command: custom
       custom: tool
-      arguments: install --tool-path . nbgv
+      arguments: install --tool-path . nbgv --version 3.6.146
     displayName: Install NBGV tool
   
   - script: nbgv cloud
     displayName: Set Version
-
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '7.0.302'
-    displayName: Use .NET SDK 7.0.302
     
   - powershell: .\build\build.ps1
     displayName: Build 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,6 +55,12 @@ jobs:
       version: '5.0.402'
     displayName: Use .NET SDK 5.0.402
 
+  - task: UseDotNet@2
+    inputs:
+      packageType: 'sdk'
+      version: '8.0.x'
+    displayName: Use .NET SDK 8.x
+
   - template: build/ci/dotnet-install-windows.yml
   - template: build/ci/jdk-setup.yml
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -73,6 +73,12 @@ jobs:
   
   - script: nbgv cloud
     displayName: Set Version
+
+  - task: UseDotNet@2
+    inputs:
+      packageType: 'sdk'
+      version: '7.0.302'
+    displayName: Use .NET SDK 7.0.302
     
   - powershell: .\build\build.ps1
     displayName: Build 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.204",
+  "version": "7.1.205",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
## Summary
This PR bumps the stable package version on unorel/winui/7.1.200 from 7.1.204 to 7.1.205.

## Why
All required client backports are now in the release branch, and a clean stable increment is needed for the next release.

## Issue
Related to https://github.com/unoplatform/kahua-private/issues/392