### PR TITLE
fix(ci): use .NET 8 only for signing step

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,6 +71,12 @@ jobs:
   - powershell: .\build\build.ps1
     displayName: Build 
 
+  - task: UseDotNet@2
+    inputs:
+      packageType: 'sdk'
+      version: '8.0.x'
+    displayName: Use .NET SDK 8.x for signing
+
   - template: build/ci/sign-packages.yml
 
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
## Summary
Adds a .NET 8 SDK install step immediately before the signing stage in the legacy CI pipeline.

## Why
After PR #232 merge, build 199949 fails during Authenticode Sign Packages because the sign tool now targets 
et8.0.
This keeps restore/build on existing SDK flow and upgrades SDK only for the signing tool invocation.

## Issue
Related to https://github.com/unoplatform/kahua-private/issues/392