### PR TITLE
chore: bump dev version to 7.1.206

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.205-dev.{height}",
+  "version": "7.1.206-dev.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
## Summary
Bumps the default branch prerelease line from 7.1.205-dev.{height} to 7.1.206-dev.{height}.

## Why
Stable 7.1.205 is released, so new prerelease packages should move to the next dev line.
