### PR TITLE
chore: bump stable version to 7.1.206

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.205",
+  "version": "7.1.206",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
## What

Bump the stable line `version.json` from `7.1.205` → **`7.1.206`** so the branch build publishes a new stable release.

Same mechanism as the dev bump #234, but on the `unorel/winui/7.1.200` servicing branch (whose `publicReleaseRefSpec` marks it as a public, non-prerelease release).

## Why now

`7.1.205` is already published on nuget.org (verified across all `Uno.CommunityToolkit.*` packages). Since it shipped, the following have merged into `unorel/winui/7.1.200` and are not yet released:

- **#237** — backport of #235 (snap WrapPanel positions to pixel grid for display scale)
- **#239** — backport of #236 (refine WrapPanel pixel snapping: separate ceil/floor for sizes vs positions)
- **#238** — CI fix (build stable on .NET 8 SDK + .NET 8 uno.check workload band)

Without a version bump the branch build would just re-push the already-published `7.1.205` (no-op).

This follows the established cadence — `7.1.205-dev.N` → stable `7.1.205` → `7.1.206-dev.N` (current dev) → stable **`7.1.206`**.

## After merge

- The `refs/heads/unorel/winui/7.1.200` branch build publishes `7.1.206` (signing/publish run on non-PR builds).
- Dev (`uno`) should then bump `7.1.206-dev` → `7.1.207-dev` to stay ahead of the released stable (mirrors #234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
