### PR TITLE
fix: support desktop windows in ThemeListener

### DIFF
--- a/CommunityToolkit.WinUI.UI/Helpers/ThemeListener.cs
+++ b/CommunityToolkit.WinUI.UI/Helpers/ThemeListener.cs
@@ -57,6 +57,7 @@ namespace CommunityToolkit.WinUI.UI.Helpers
 
         private AccessibilitySettings _accessible = new AccessibilitySettings();
         private UISettings _settings = new UISettings();
+        private readonly Window _window;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ThemeListener"/> class.
@@ -73,12 +74,15 @@ namespace CommunityToolkit.WinUI.UI.Helpers
 
             DispatcherQueue = dispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
 
-            if (Window.Current != null)
+            _window = Window.Current;
+            if (_window != null)
             {
                 _accessible.HighContrastChanged += Accessible_HighContrastChanged;
                 _settings.ColorValuesChanged += Settings_ColorValuesChanged;
 
-                Window.Current.CoreWindow.Activated += CoreWindow_Activated;
+                // Desktop windows (including Uno Skia) do not have a CoreWindow. Subscribe to the
+                // XAML window event so both desktop and CoreWindow-backed hosts retain activation updates.
+                _window.Activated += Window_Activated;
             }
         }
 
@@ -120,13 +124,13 @@ namespace CommunityToolkit.WinUI.UI.Helpers
                 }, DispatcherQueuePriority.Normal);
         }
 
-        private void CoreWindow_Activated(Windows.UI.Core.CoreWindow sender, Windows.UI.Core.WindowActivatedEventArgs args)
+        private void Window_Activated(object sender, WindowActivatedEventArgs args)
         {
             if (CurrentTheme != Application.Current.RequestedTheme ||
                 IsHighContrast != _accessible.HighContrast)
             {
 #if DEBUG
-                global::System.Diagnostics.Debug.WriteLine("CoreWindow Activated Changed");
+                global::System.Diagnostics.Debug.WriteLine("Window Activated Changed");
 #endif
 
                 UpdateProperties();
@@ -160,9 +164,9 @@ namespace CommunityToolkit.WinUI.UI.Helpers
         {
             _accessible.HighContrastChanged -= Accessible_HighContrastChanged;
             _settings.ColorValuesChanged -= Settings_ColorValuesChanged;
-            if (Window.Current != null)
+            if (_window != null)
             {
-                Window.Current.CoreWindow.Activated -= CoreWindow_Activated;
+                _window.Activated -= Window_Activated;
             }
         }
     }

--- a/UnitTests/UnitTests.XamlIslands.UWPApp/XamlIslandsTest_ThemeListener_Threading.cs
+++ b/UnitTests/UnitTests.XamlIslands.UWPApp/XamlIslandsTest_ThemeListener_Threading.cs
@@ -36,6 +36,24 @@ namespace UnitTests.XamlIslands.UWPApp
             });
         }
 
+        [TestCleanup]
+        public Task Cleanup()
+        {
+            return App.Dispatcher.EnqueueAsync(() => _themeListener.Dispose());
+        }
+
+        [TestMethod]
+        public async Task ThemeListenerCanBeCreatedAndDisposedForCurrentWindowAsync()
+        {
+            await App.Dispatcher.EnqueueAsync(() =>
+            {
+                using var listener = new ThemeListener();
+                Assert.AreEqual(Application.Current.RequestedTheme, listener.CurrentTheme);
+                Assert.IsNotNull(listener.DispatcherQueue);
+                listener.Dispose();
+            });
+        }
+
         [TestMethod]
         public async Task ThemeListenerDispatcherTestAsync()
         {


### PR DESCRIPTION
## Fixes

Prevent `ThemeListener` from dereferencing a missing `CoreWindow` when the current XAML window uses the desktop implementation, including Uno Skia Desktop and Skia WebAssembly.

## PR Type

- Bugfix

## What is the current behavior?

`ThemeListener` checks `Window.Current != null`, then subscribes to `Window.Current.CoreWindow.Activated`. Uno 6.7 desktop windows have a current `Window` but no `CoreWindow`. Creating a `MarkdownTextBlock` therefore throws `NullReferenceException` from `ThemeListener` during `Loaded` and `OnApplyTemplate`; disposing the listener uses the same invalid assumption.

The issue reproduced with the published `Uno.CommunityToolkit.WinUI.UI.Controls.Markdown` 7.1.206 and Uno.WinUI 6.7.103 in a real Skia Desktop app. A GUI gate passed plain-text and same-size text update cases, then failed when its Markdown case loaded the control.

## What is the new behavior?

Capture the current XAML `Window` once, subscribe to its native `Activated` event, and unsubscribe from that same window during disposal. The existing `UISettings.ColorValuesChanged`, high-contrast notifications, dispatcher, and theme comparison remain in place. No public API or rendered Markdown behavior is changed.

## PR Checklist

- [x] Upstream Windows and Linux CI passed for the current PR head
- [x] Tests for creation and disposal have been added to the existing ThemeListener fixture
- [x] Contains no breaking public API changes

## Other information

Upstream Azure CI build 233351 passed both Windows and Linux jobs for PR head `1e4c8e8e05626c031cfe1e7f3487f2f3a865a831` (merge commit `15b1194ecbf27fa8279647cdc7b8dad8bc14eb62`). The existing XAML Islands tests have not been executed locally. A focused consumer build from stable commit `e6229e8782e703856726d692de1fc9d27e3cbff5` plus this patch restored successfully, but did not reach compilation on Linux ARM64: the pinned Nerdbank.GitVersioning 3.3.37 native git backend requires `libssl.so.1.1`, which is absent on the host. No workaround changes to the consumer application or installed published NuGet cache entries were made.

Consumer validation used the unmodified UI package built by that official CI (`7.1.207-dev.4.g15b1194ecb`) plus its matching toolkit dependencies in an isolated package source. The downstream Uno 6.7.103 Desktop build completed without warnings or errors, and the real Markdown control loaded without the original `ThemeListener` exception. Further downstream read-receipt verification is separate from this constructor fix; this PR does not claim it has passed. The constructor/disposal test retains coverage on the existing Windows/XAML Islands fixture.
